### PR TITLE
guard against missing JSON key

### DIFF
--- a/waltz/resources/quizzes/fill_in_multiple_blanks_question.py
+++ b/waltz/resources/quizzes/fill_in_multiple_blanks_question.py
@@ -19,7 +19,7 @@ class FillInMultipleBlanksQuestion(QuizQuestion):
                     result['answers'][blank_id] = []
                 a = CommentedMap()
                 a['text'] = answer['text']
-                if answer['comments_html']:
+                if 'comments_html' in answer and answer['comments_html']:
                     a['comment'] = h2m(answer['comments_html'])
                 result['answers'][blank_id].append(a)
         return result


### PR DESCRIPTION
I tried exporting a quiz and got a KeyError crash. This patch guards against the case I observed.